### PR TITLE
Establish Zookeeper ensemble based on FQDNs of pods in StatefulSet

### DIFF
--- a/src/ingestion/client/zookeeper/__init__.py
+++ b/src/ingestion/client/zookeeper/__init__.py
@@ -1,6 +1,6 @@
 from kazoo.client import KazooClient
 from .client import KazooZookeeperClient
 import logging
+import os
 
-
-client = KazooZookeeperClient(KazooClient(hosts='127.0.0.1:2181', logger=logging.getLogger(__name__)))
+client = KazooZookeeperClient(KazooClient(hosts=os.getenv('ZOO_SERVERS'), logger=logging.getLogger(__name__)))

--- a/src/ingestion/zookeeper.yaml
+++ b/src/ingestion/zookeeper.yaml
@@ -75,6 +75,28 @@ spec:
         env:
           - name: ZOO_4LW_COMMANDS_WHITELIST
             value: "*"
+          - name: ZOO_MY_ID
+            valueFrom:
+              fieldRef:
+                # We need a way to assign each Zookeeper server in the ensemble a unique ID.
+                # The easiest way is to use the ordinal index, which is available with the pod-index
+                # label in a StatefulSet.
+                # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-index-label
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          - name: ZOO_SERVERS
+            # We need the FQDNs of each pod in our headless service, but it's not possible to get this value
+            # dynamically based on the number of replicas we are using. Based on the DNS documenation for services,
+            # FQDNs are formatted as <pod-name>.<service name>.<namespace>.svc.<cluster domain>, so they are listed
+            # exhaustively here.
+            # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+            value: |
+              server.0=zk-0.zk-hs.default.svc.cluster.local:2888:3888;2181
+              server.1=zk-1.zk-hs.default.svc.cluster.local:2888:3888;2181
+              server.2=zk-2.zk-hs.default.svc.cluster.local:2888:3888;2181
+          - name: ZOO_CFG_EXTRA
+            # Based on the Zookeeper configuration documentation, the following configurations in zoo.cfg are required.
+            # https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_minimumConfiguration
+            value: "clientPort=2181 dataDir=/data tickTime=2000 dataLogDir=/datalog"
         resources:
           requests:
             memory: "1Gi"
@@ -106,9 +128,6 @@ spec:
               grep \"imok\""
           initialDelaySeconds: 10
           timeoutSeconds: 5
-        volumeMounts:
-        - name: datadir
-          mountPath: /var/lib/zookeeper
       - name: ingestion-service
         imagePullPolicy: Always
         image: localhost:5000/ingestion-service
@@ -116,13 +135,15 @@ spec:
           requests:
             memory: "0.3Gi"
             cpu: "0.4"
+        env:
+          - name: POD_INDEX
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          - name: ZOO_SERVERS
+            value: |
+              zk-0.zk-hs.default.svc.cluster.local:2181,
+              zk-1.zk-hs.default.svc.cluster.local:2181,
+              zk-2.zk-hs.default.svc.cluster.local:2181
       securityContext:
         runAsUser: 0
-  volumeClaimTemplates:
-  - metadata:
-      name: datadir
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 10Gi


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- Closes #15 

## Description
<!-- Brief but accurate description for issues and solution proposed -->
- We are currently hardcoding the hosts used in our Zookeeper client. We need to change this to a comma-separated list of fully qualified domain names (FQDNs) so that each pod in our StatefulSet can form an ensemble. The solution introduced in c05ccf0b099f0a04d9ad03973c9f55fff63a0908 includes the following:
  - We use the `apps.kubernetes.io/pod-index` to assign each replica in the ensemble a unique ID based on its [ordinal index](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#ordinal-index). The ordinal index is a unique identifier that does not change for a replica (even if it crashes, relocates etc.). Since this identifier is essentially immutable for each replica, this will allow any replica in our ensemble to understand exactly which instance it actually is.
  - Since the ordinal index of each replica does not change, we use the ordinal index and total number of replicas to add the FQDNs of each host for the `ZOO_SERVERS` Zookeeper configuration. Since we know both the ordinal indices and total replicas, the FQDNs for a StatefulSet can be formatted based on the following [documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
  - The Zookeeper client was updated to use the FQDNs of each Zookeeper server.
- The volume from #12 was removed because it's not needed anymore.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [x] Environment tests
- [ ] Regression tests
- [ ] Smoke tests


Since we are testing an ensemble configuration, local environment tests with a Minikube cluster were performed in order to verify that our ensemble is set up correctly.
- We used `zkServer.sh` on the kubernetes-zookeeper container to check that only one replica has the leader status, and all other replicas have the follower status.
- We checked the Zookeeper configuration file in `zoo.cfg` to make sure the FQDNs for each server are added correctly.
- We added a ZNode on one Zookeeper server and checked for its existence on another Zookeeper server in the ensemble.

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="651" height="60" alt="Screen Shot 2025-12-24 at 1 59 31 PM" src="https://github.com/user-attachments/assets/ed245c68-3160-458b-8806-5bf0e3afda0d" />
<img width="503" height="68" alt="Screen Shot 2025-12-24 at 1 58 59 PM" src="https://github.com/user-attachments/assets/4566c807-9496-426b-815a-6142909a3189" />
<img width="641" height="335" alt="Screen Shot 2025-12-24 at 1 42 13 PM" src="https://github.com/user-attachments/assets/4bda5a7d-36e1-4c97-b5c0-89b7dad84182" />
<img width="693" height="291" alt="Screen Shot 2025-12-26 at 10 35 25 AM" src="https://github.com/user-attachments/assets/ed3af804-79f8-4fa2-a543-fbdc910dc455" />
