### PR TITLE
Chore: Adjust gunicorn worker and threads; add bridge network for testing

### DIFF
--- a/src/streaming/Dockerfile
+++ b/src/streaming/Dockerfile
@@ -8,4 +8,4 @@ COPY . .
 RUN pip3 install -r requirements.txt
 WORKDIR /
 
-CMD ["gunicorn", "streaming.main:app", "--worker-class", "sync", "--workers", "2", "--bind", "0.0.0.0:8000"]
+CMD ["gunicorn", "streaming.main:app", "--worker-class", "gthread", "--workers", "3", "--threads", "10", "--bind", "0.0.0.0:8000"]

--- a/test/integration_tests/streaming/docker-compose.yml
+++ b/test/integration_tests/streaming/docker-compose.yml
@@ -28,6 +28,9 @@ services:
         target: ${GOOGLE_APPLICATION_CREDENTIALS}
     ports:
       - "8000:8000"
+    networks:
+      - default
+      # - bridge
     depends_on:
       - firestore_emulator
       - redis
@@ -48,3 +51,8 @@ services:
       - firestore_emulator
       - streaming
       - redis
+networks:
+  bridge:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- N/A

## Description
<!-- Brief but accurate description for issues and solution proposed -->
- We need some miscellaneous changes in 1ad7daa57d924b4c3e1872ca4057f6f9b0508640 to fix some missed issues and to help with future testing:
  - The mentioned commit first adjusts the gunicorn configuration for our streaming service. This is done because (while the gunicorn worker process accepting the streaming request still streams to the client), there are no other threads created for the worker processes. Based on the [documentation](https://gunicorn.org/reference/settings/#threads), one thread is created, which causes the gunicorn worker to stop responding to heartbeats from the master process and become SIGKILLED after 30 seconds or so. The configuration was adjusted to increase the number of threads to prevent this from happening. The worker class was updated to use `gthread` as well since based on the same [documentation](https://gunicorn.org/reference/settings/#worker_class), gthread will be used instead of sync if the number of threads is more than 1.
  - The mentioned commit also adds a bridge network to the integration test for the streaming service. The [bridge network driver documentation](https://docs.docker.com/engine/network/drivers/bridge/) mentions that the bridge network driver can be used when we want the Docker host to have access to containers connected to the bridge network. We might want to troubleshoot the API endpoints some time in the future without having to set up a separate container and troubleshoot what network to connect to for troubleshooting. The bridge network is amended to the streaming network as a comment for these cases.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="566" height="262" alt="Screen Shot 2026-02-04 at 10 09 14 PM" src="https://github.com/user-attachments/assets/3cdaec68-d53e-438e-bb0c-936cd2a4495b" />
