### PR TITLE
Added fault tolerance based implementation of Open Notify client

### DIFF
--- a/src/ingestion/client/open_notify/client.py
+++ b/src/ingestion/client/open_notify/client.py
@@ -1,29 +1,33 @@
-"""
+'''
 Open Notify client module for ISS location API.
-"""
+'''
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from logging import Logger
 
 import requests
+from hyx.circuitbreaker import consecutive_breaker
+from hyx.retry import retry
+from requests.exceptions import HTTPError
 
 
 class OpenNotifyClient(ABC):
-  """
+  '''
   Abstract base class for Open Notify API client 
   http://open-notify.org/Open-Notify-API/ISS-Location-Now/
-  """
+  '''
 
   @abstractmethod
-  def get_iss(self):
+  def get_iss(self) -> dict:
     pass
 
 
 class OpenNotifyRequestsClient(OpenNotifyClient):
-  """
+  '''
   Open Notify API client implementation with requests module.
-  """
+  '''
 
   def __init__(self,
                hostname: str = 'http://api.open-notify.org',
@@ -34,7 +38,7 @@ class OpenNotifyRequestsClient(OpenNotifyClient):
     self._timeout = timeout
     self._logger = logger
 
-  def get_iss(self):
+  def get_iss(self) -> dict:
     endpoint = f'{self._hostname}{self._iss_path}'
     self._logger.warning(f'Requesting for ISS data [endpoint={endpoint}]')
     response = requests.get(endpoint, timeout=self._timeout)
@@ -45,3 +49,29 @@ class OpenNotifyRequestsClient(OpenNotifyClient):
         'Successfully requested for ISS data [response_json=%s]', response_json)
 
     return response_json
+
+
+class FaultTolerantOpenNotifyRequestsClient(OpenNotifyClient):
+  '''
+  Open Notify API client with retries and circuit breaker pattern.
+  '''
+
+  breaker = consecutive_breaker(exceptions=(requests.Timeout, HTTPError),
+                                failure_threshold=5,
+                                recovery_time_secs=30,
+                                recovery_threshold=1)
+
+  def __init__(self, client: OpenNotifyClient):
+    self._client = client
+
+  def get_iss(self) -> dict:
+    return asyncio.run(self._get_iss_from_client())
+
+  @retry(on=(requests.Timeout, HTTPError), attempts=3, backoff=1)
+  @breaker
+  async def _get_iss_from_client(self) -> dict:
+    # Circuit breaker with hyx wraps the decorated function with an async
+    # wrapper function. This creates a coroutine, so we need to create a
+    # separate method for this and call asyncio.run(..) to prevent the
+    # interpreter from throwing any warnings.
+    return self._client.get_iss()

--- a/src/ingestion/main.py
+++ b/src/ingestion/main.py
@@ -11,7 +11,9 @@ from iss_location_client.client import ISSLocationFirestoreClient
 from iss_location_client.iss_location import ISSLocation
 from kazoo.client import KazooClient
 
-from .client.open_notify.client import OpenNotifyRequestsClient
+from .client.open_notify.client import (FaultTolerantOpenNotifyRequestsClient,
+                                        OpenNotifyClient,
+                                        OpenNotifyRequestsClient)
 from .client.zookeeper.client import Client, KazooZookeeperClient
 from .election.facade import ElectionFacade, SequentialEphemeralElectionFacade
 from .util.signal_handler import SignalHandler, ZooKeeperSignalHandler
@@ -28,9 +30,11 @@ def get_config() -> Config:
   return config
 
 
-def get_open_notify_client() -> OpenNotifyRequestsClient:
+def get_open_notify_client() -> OpenNotifyClient:
   open_notify_client = OpenNotifyRequestsClient()
-  return open_notify_client
+  fault_tolerant_open_notify_client = FaultTolerantOpenNotifyRequestsClient(
+      client=open_notify_client)
+  return fault_tolerant_open_notify_client
 
 
 def get_iss_firestore_client() -> ISSLocationFirestoreClient:

--- a/src/ingestion/requirements.txt
+++ b/src/ingestion/requirements.txt
@@ -28,6 +28,7 @@ hpack==4.1.0
 httpcore==1.0.9
 httpx==0.28.1
 hyperframe==6.1.0
+hyx==0.0.2
 idna==3.11
 importlib_metadata==8.7.0
 isort==6.1.0

--- a/test/integration_tests/ingestion/Dockerfile.it
+++ b/test/integration_tests/ingestion/Dockerfile.it
@@ -5,4 +5,4 @@ COPY src/ingestion src/ingestion
 COPY test/integration_tests/ingestion test/integration_tests/ingestion
 RUN pip3 install -r src/ingestion/requirements.txt
 
-CMD [ "python3", "-m", "unittest", "discover", "test/integration_tests" ]
+CMD [ "python3", "-m", "unittest", "discover", "--verbose", "test/integration_tests" ]

--- a/test/integration_tests/ingestion/client/open_notify/test_client.py
+++ b/test/integration_tests/ingestion/client/open_notify/test_client.py
@@ -1,12 +1,13 @@
 ''' Integration test module for Open Notify client. '''
 import unittest
 
-from src.ingestion.client.open_notify.client import OpenNotifyRequestsClient
+from src.ingestion.client.open_notify.client import (
+    FaultTolerantOpenNotifyRequestsClient, OpenNotifyRequestsClient)
 
 
 class OpenNotifyRequestsClientTestSuite(unittest.TestCase):
   '''
-  Test suite for OpenNotifyRequestsClient.
+  Integration test suite for OpenNotifyRequestsClient.
   '''
 
   def setUp(self) -> None:
@@ -21,3 +22,14 @@ class OpenNotifyRequestsClientTestSuite(unittest.TestCase):
     self.assertIsNotNone(response['iss_position'])
     self.assertIsNotNone(response['iss_position']['latitude'])
     self.assertIsNotNone(response['iss_position']['longitude'])
+
+
+class FaultTolerantOpenNotifyRequestsClientTestSuite(
+    OpenNotifyRequestsClientTestSuite):
+  '''
+  Integration test suite for FaultTolerantOpenNotifyRequestsClient.
+  '''
+
+  def setUp(self) -> None:
+    self._client = FaultTolerantOpenNotifyRequestsClient(
+        client=OpenNotifyRequestsClient())


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- Towards #38 

## Description
<!-- Brief but accurate description for issues and solution proposed -->
- We need to build resiliency patterns into the clients of our app, since they are prone to failure. This pull request adds a circuit breaker and retry mechanism with the [hyx](https://hyx.readthedocs.io/en/latest/) package to the Open Notify client.

## Tests Included
- [ ] Unit tests
- [X]  Integration tests
- [ ] Environment tests
- [X] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
