### PR TITLE
Chore: Bump iss-location-client to `1.0.1` in ingestion

### DIFF
--- a/src/ingestion/requirements.txt
+++ b/src/ingestion/requirements.txt
@@ -6,7 +6,7 @@ CacheControl==0.14.3
 cachetools==6.2.4
 certifi==2025.11.12
 cffi==2.0.0
-cfg-environ==1.0.0
+cfg-environ==1.0.1
 charset-normalizer==3.4.4
 click==8.1.8
 coverage==7.10.7
@@ -36,7 +36,7 @@ hyx==0.0.2
 idna==3.11
 importlib_metadata==8.7.0
 isort==6.1.0
-iss-location-client==1.0.0
+iss-location-client==1.0.1
 itsdangerous==2.2.0
 Jinja2==3.1.6
 kazoo==2.10.0


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- N/A

## Description
<!-- Brief but accurate description for issues and solution proposed -->

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [ ] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
