### PR TITLE
Moved k8s configuration data into ConfigMaps

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configuration
+data:
+  ZOO_4LW_COMMANDS_WHITELIST: "*"
+  # We need the FQDNs of each pod in our headless service, but it's not possible to get this value
+  # dynamically based on the number of replicas we are using. Based on the DNS documenation for services,
+  # FQDNs are formatted as <pod-name>.<service name>.<namespace>.svc.<cluster domain>, so they are listed
+  # exhaustively here.
+  # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+  ZOO_SERVERS: |
+    server.0=zk-0.zk-hs.default.svc.cluster.local:2888:3888;2181
+    server.1=zk-1.zk-hs.default.svc.cluster.local:2888:3888;2181
+    server.2=zk-2.zk-hs.default.svc.cluster.local:2888:3888;2181
+  INGESTION_ZOO_SERVERS: |
+    zk-0.zk-hs.default.svc.cluster.local:2181,
+    zk-1.zk-hs.default.svc.cluster.local:2181,
+    zk-2.zk-hs.default.svc.cluster.local:2181
+  # Based on the Zookeeper configuration documentation, the following configurations in zoo.cfg are required.
+  # https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_minimumConfiguration
+  ZOO_CFG_EXTRA: "clientPort=2181 dataDir=/data tickTime=2000 dataLogDir=/datalog"
+  ENVIRONMENT: "development"
+  GOOGLE_CLOUD_PROJECT: open-notify
+  GCLOUD_PROJECT: open-notify
+  FIRESTORE_EMULATOR_HOST: firestore-service.default.svc.cluster.local:8080
+  FIRESTORE_PROJECT_ID: open-notify

--- a/ingestion.yaml
+++ b/ingestion.yaml
@@ -75,7 +75,10 @@ spec:
         image: "zookeeper:latest"
         env:
           - name: ZOO_4LW_COMMANDS_WHITELIST
-            value: "*"
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: ZOO_4LW_COMMANDS_WHITELIST
           - name: ZOO_MY_ID
             valueFrom:
               fieldRef:
@@ -85,19 +88,15 @@ spec:
                 # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-index-label
                 fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
           - name: ZOO_SERVERS
-            # We need the FQDNs of each pod in our headless service, but it's not possible to get this value
-            # dynamically based on the number of replicas we are using. Based on the DNS documenation for services,
-            # FQDNs are formatted as <pod-name>.<service name>.<namespace>.svc.<cluster domain>, so they are listed
-            # exhaustively here.
-            # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
-            value: |
-              server.0=zk-0.zk-hs.default.svc.cluster.local:2888:3888;2181
-              server.1=zk-1.zk-hs.default.svc.cluster.local:2888:3888;2181
-              server.2=zk-2.zk-hs.default.svc.cluster.local:2888:3888;2181
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: ZOO_SERVERS
           - name: ZOO_CFG_EXTRA
-            # Based on the Zookeeper configuration documentation, the following configurations in zoo.cfg are required.
-            # https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_minimumConfiguration
-            value: "clientPort=2181 dataDir=/data tickTime=2000 dataLogDir=/datalog"
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: ZOO_CFG_EXTRA
         resources:
           requests:
             memory: "1Gi"
@@ -142,15 +141,24 @@ spec:
               fieldRef:
                 fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
           - name: ZOO_SERVERS
-            value: |
-              zk-0.zk-hs.default.svc.cluster.local:2181,
-              zk-1.zk-hs.default.svc.cluster.local:2181,
-              zk-2.zk-hs.default.svc.cluster.local:2181
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: INGESTION_ZOO_SERVERS
           - name: ENVIRONMENT
-            value: "development"
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: ENVIRONMENT
           - name: FIRESTORE_EMULATOR_HOST
-            value: firestore-service.default.svc.cluster.local:8080
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: FIRESTORE_EMULATOR_HOST
           - name: FIRESTORE_PROJECT_ID
-            value: open-notify
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: FIRESTORE_PROJECT_ID
       securityContext:
         runAsUser: 0

--- a/streaming.yaml
+++ b/streaming.yaml
@@ -61,11 +61,20 @@ spec:
               name: firestore-port
           env:
             - name: FIRESTORE_PROJECT_ID
-              value: open-notify
+              valueFrom:
+                configMapKeyRef:
+                  name: configuration
+                  key: FIRESTORE_PROJECT_ID
             - name: GOOGLE_CLOUD_PROJECT
-              value: open-notify
+              valueFrom:
+                configMapKeyRef:
+                  name: configuration
+                  key: GOOGLE_CLOUD_PROJECT
             - name: GCLOUD_PROJECT
-              value: open-notify
+              valueFrom:
+                configMapKeyRef:
+                  name: configuration
+                  key: GCLOUD_PROJECT
 ---
 apiVersion: v1
 kind: Service
@@ -105,9 +114,15 @@ spec:
           name: streaming-port
         env:
           - name: FIRESTORE_EMULATOR_HOST
-            value: firestore-service.default.svc.cluster.local:8080
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: FIRESTORE_EMULATOR_HOST
           - name: FIRESTORE_PROJECT_ID
-            value: open-notify
+            valueFrom:
+              configMapKeyRef:
+                name: configuration
+                key: FIRESTORE_PROJECT_ID
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- Closes #63 

## Description
<!-- Brief but accurate description for issues and solution proposed -->
- This pull request adds [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) support to the existing k8s specs used for streaming and ingestion. This is motivated by the following:
  - We want to decouple configuration for our k8s cluster from the environment it's running in (in case we want to run across multiple environments)
  - ConfigMaps are needed anyways for us to implement the changes in #57 due to the reliance on ConfigMapGenerators.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="833" height="831" alt="Screen Shot 2026-02-24 at 10 52 54 PM" src="https://github.com/user-attachments/assets/af7c2ac5-a3b0-4923-8e39-f7535db79d62" />
<img width="794" height="717" alt="Screen Shot 2026-02-24 at 10 52 03 PM" src="https://github.com/user-attachments/assets/13b37566-9da4-4938-8419-5571e371d78b" />
<img width="864" height="384" alt="Screen Shot 2026-02-24 at 10 26 31 PM" src="https://github.com/user-attachments/assets/e2cd2bde-a967-41c1-bef1-a7ee88af6b7b" />
<img width="892" height="336" alt="Screen Shot 2026-02-24 at 10 26 10 PM" src="https://github.com/user-attachments/assets/ef898e09-9509-43c0-a257-dc10e18c0786" />
