### PR TITLE
Added Git hook script for UT and linting on commits

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,7 @@
+# Pre-commit hook
+
+The [pre-commit](./pre-commit) hook script does the following:
+1. Runs the unit tests for streaming and ingestion services
+2. Runs pylint across streaming and ingestion services.
+
+To set up the pre-commit script, copy the pre-commit script into the `.git/hooks/` directory of your local repository.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+
+# Intepreter location
+docker=$(which docker)
+python=$(which python)
+
+echo "UNIT TEST REGRESSION ON YOUR BULLSHIT CHANGES"
+docker build -t ingestion-test:latest --file test/unit_tests/ingestion/Dockerfile .
+docker run ingestion-test:latest
+
+docker build -t streaming-test:latest --file test/unit_tests/streaming/Dockerfile .
+docker run streaming-test:latest
+
+python -m pylint src/ test/ --rcfile=.pylintrc

--- a/test/unit_tests/ingestion/Dockerfile
+++ b/test/unit_tests/ingestion/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-alpine3.22
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /
+COPY  src/ingestion src/ingestion
+COPY test/unit_tests/ingestion test/unit_tests/ingestion
+
+RUN pip install -r src/ingestion/requirements.txt
+
+CMD [ "python3", "-m", "unittest", "discover", "--verbose", "test/unit_tests/ingestion" ]

--- a/test/unit_tests/streaming/Dockerfile
+++ b/test/unit_tests/streaming/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-alpine3.22
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /
+
+COPY src/streaming src/streaming
+COPY test/unit_tests/streaming test/unit_tests/streaming
+
+RUN pip install -r src/streaming/requirements.txt
+
+CMD [ "python3", "-m", "unittest", "discover", "--verbose", "test/unit_tests/streaming" ]


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- Closes #65 

## Description
<!-- Brief but accurate description for issues and solution proposed -->
- This pull request introduces a pre-commit Git hook script which runs UT regression and linting on every commit.
  - To make these changes, we used the [Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) documentation to understand how to provision a script that will execute every time a commit is made. The screenshots below show the `pre-commit` script running when a commit is introduced with git.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="987" height="771" alt="Screen Shot 2026-02-26 at 9 59 45 PM" src="https://github.com/user-attachments/assets/9977a423-211b-4493-b30e-5ed1c2dde763" />
<img width="994" height="1596" alt="Screen Shot 2026-02-26 at 9 59 34 PM" src="https://github.com/user-attachments/assets/9e747842-377d-482e-8513-3595381ee343" />
