### PR TITLE
Change from regional to zonal cluster due to free tier restrictions

### DIFF
--- a/infra/terraform/kubernetes_engine.tf
+++ b/infra/terraform/kubernetes_engine.tf
@@ -1,6 +1,6 @@
 resource "google_container_cluster" "primary" {
   name     = "cluster-primary"
-  location = var.region
+  location = var.availability-zone
 
   remove_default_node_pool = true
   initial_node_count       = 1
@@ -9,7 +9,7 @@ resource "google_container_cluster" "primary" {
 
 resource "google_container_node_pool" "primary_nodes" {
   name       = "primary-node-pool"
-  location   = var.region
+  location   = var.availability-zone
   cluster    = google_container_cluster.primary.name
   node_count = var.container-cluster-node-count
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -11,7 +11,7 @@ variable "region" {
 }
 
 variable "availability-zone" {
-  default = "us-east1-a"
+  default = "us-east1-b"
 }
 
 variable "service-account" {
@@ -19,7 +19,7 @@ variable "service-account" {
 }
 
 variable "container-cluster-node-count" {
-  default = 1
+  default = 3
 }
 
 variable "container-node-pool-machine-type" {


### PR DESCRIPTION
## Related Issue
<!-- Related issues go here -->
- N/A

## Description
<!-- Brief but accurate description for issues and solution proposed -->
- [GKE free tier](https://cloud.google.com/kubernetes-engine/pricing?hl=en#cluster-management-fee) credits only applies to zonal clusters. Since we are using a regional cluster, this pull request re-provisions the GKE cluster in the `us-east1-b` availability zone.

## Tests Included
- [ ] Unit tests
- [ ]  Integration tests
- [X] Environment tests
- [ ] Regression tests
- [ ] Smoke tests

## Screenshots
<!-- Optional if screenshots provide clarity/context -->
<img width="757" height="187" alt="Screen Shot 2026-04-05 at 8 50 04 PM" src="https://github.com/user-attachments/assets/5512ab8c-626e-467b-898a-62a1bf5159fb" />
